### PR TITLE
Remove deprecated for wp_no_robots and use escaping for string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** post, unlist posts, hide posts,  
 **Requires at least:** 4.4  
-**Tested up to:** 5.6  
-**Stable tag:** 1.1.2  
+**Tested up to:** 5.7  
+**Stable tag:** 1.1.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -36,6 +36,10 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 ## Changelog ##
+
+### 1.1.3 ###
+- Deprecated: wp_no_robots() has been deprecated.
+- Security: Use escaping for displaying unlist post description.
 
 ### 1.1.2 ###
 - Fix: Post metabox did not show the correct status if the post is unlisted or not in the classic editor.

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -92,10 +92,10 @@ class Unlist_Posts_Admin {
 		?>
 		<p>
 			<label class="checkbox-inline">
-				<input name="unlist_posts" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php echo esc_html( __( 'Unlist this post?', 'unlist-posts' ) ); ?>
+				<input name="unlist_posts" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php esc_html_e( 'Unlist this post?', 'unlist-posts' ); ?>
 			</label>
 		</p>
-		<p class="description"><?php echo esc_html( __( 'This will hide the post from your site, The post can only be accessed from direct URL.', 'unlist-posts' ) ); ?> </p>
+		<p class="description"><?php esc_html_e( 'This will hide the post from your site, The post can only be accessed from direct URL.', 'unlist-posts' ); ?> </p>
 		<?php
 	}
 

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -92,10 +92,10 @@ class Unlist_Posts_Admin {
 		?>
 		<p>
 			<label class="checkbox-inline">
-				<input name="unlist_posts" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php _e( 'Unlist this post?', 'unlist-posts' ); ?>
+				<input name="unlist_posts" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php echo esc_html( __( 'Unlist this post?', 'unlist-posts' ) ); ?>
 			</label>
 		</p>
-		<p class="description"><?php _e( 'This will hide the post from your site, The post can only be accessed from direct URL.', 'unlist-posts' ); ?> </p>
+		<p class="description"><?php echo esc_html( __( 'This will hide the post from your site, The post can only be accessed from direct URL.', 'unlist-posts' ) ); ?> </p>
 		<?php
 	}
 

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -150,7 +150,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 
 			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				wp_no_robots();
+				add_filter( 'wp_robots', 'wp_robots_no_robots' );
 			}
 		}
 

--- a/languages/unlist-posts.pot
+++ b/languages/unlist-posts.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2019 Nikhil Chavan
+# Copyright (C) 2021 Nikhil Chavan
 # This file is distributed under the same license as the Unlist Posts & Pages package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Unlist Posts & Pages 1.0.4\n"
+"Project-Id-Version: Unlist Posts & Pages 1.1.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/unlist-posts\n"
-"POT-Creation-Date: 2019-01-10 06:14:02+00:00\n"
+"POT-Creation-Date: 2021-03-10 11:43:27+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2021-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en\n"
@@ -24,21 +24,21 @@ msgstr ""
 "X-Textdomain-Support: yes\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
 
-#: class-unlist-posts-admin.php:57
+#: class-unlist-posts-admin.php:60
 msgid "Unlist Post"
 msgstr ""
 
-#: class-unlist-posts-admin.php:92
+#: class-unlist-posts-admin.php:95
 msgid "Unlist this post?"
 msgstr ""
 
-#: class-unlist-posts-admin.php:95
+#: class-unlist-posts-admin.php:98
 msgid ""
 "This will hide the post from your site, The post can only be accessed from "
 "direct URL."
 msgstr ""
 
-#: class-unlist-posts-admin.php:167
+#: class-unlist-posts-admin.php:172 class-unlist-posts-admin.php:215
 msgid "Unlisted"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "hide-post",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {
-    "grunt": "^1.0.4",
-    "grunt-wp-i18n": "~1.0.3",
+    "grunt": "^1.3.0",
+    "grunt-wp-i18n": "^1.0.3",
     "grunt-wp-readme-to-markdown": "^2.0.1"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: brainstormforce, Nikschavan
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: post, unlist posts, hide posts,
 Requires at least: 4.4
-Tested up to: 5.6
-Stable tag: 1.1.2
+Tested up to: 5.7
+Stable tag: 1.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,10 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 == Changelog ==
+
+= 1.1.3 =
+- Deprecated: wp_no_robots() has been deprecated.
+- Security: Use escaping for displaying unlist post description.
 
 = 1.1.2 =
 - Fix: Post metabox did not show the correct status if the post is unlisted or not in the classic editor.

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
  * Domain Path:     /languages
- * Version:         1.1.2
+ * Version:         1.1.3
  *
  * @package         Hide_Post
  */
@@ -16,6 +16,6 @@ defined( 'ABSPATH' ) or exit;
 
 define( 'UNLIST_POSTS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UNLIST_POSTS_URI', plugins_url( '/', __FILE__ ) );
-define( 'UNLIST_POSTS_VER', '1.1.2' );
+define( 'UNLIST_POSTS_VER', '1.1.3' );
 
 require_once UNLIST_POSTS_DIR . 'class-unlist-posts.php';


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Updated tested up to tag.
- [Remove wp_no_robots() and used wp_robots_no_robots() instead](https://developer.wordpress.org/reference/functions/wp_no_robots/).
- Security: Use escaping for displaying unlist post description.
( _e() is not an escaping function. And all output really needs to be escaped, So I have used __() instead.)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Check is post/page unlist in the block editor as well as the classic editor.
- No warning/notice on the frontend. Everything working fine.

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
