### PR TITLE
Fix: Robots tags conflicting with Yoast SEO.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Just select option "Unlist Post" in any post of any type and that post will be h
 
 ## Changelog ##
 ### 1.1.5 ###
-- Fix: Robots tags conflicting with Yoast SEO.
+- Fix: Compatibility with Yoast SEO's robots tags options. Robots tags from Unlist Posts will override tag changes from Yoast SEO.
 
 ### 1.1.4 ###
 - Fix: Due to a bug unlisted posts were visible in the search results, which we have fixed now.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** post, unlist posts, hide posts,  
 **Requires at least:** 4.4  
 **Tested up to:** 5.7  
-**Stable tag:** 1.1.4  
+**Stable tag:** 1.1.5  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -36,6 +36,8 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 ## Changelog ##
+### 1.1.5 ###
+- Fix: Robots tags conflicting with Yoast SEO.
 
 ### 1.1.4 ###
 - Fix: Due to a bug unlisted posts were visible in the search results, which we have fixed now.

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -175,6 +175,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 
 			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
+				add_filter( 'wpseo_robots_array', '__return_empty_array' );
 				return wp_robots_no_robots( $robots );
 			}
 			return $robots;

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -175,6 +175,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 
 			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
+				// Disable robots tags from Yoast SEO.
 				add_filter( 'wpseo_robots_array', '__return_empty_array' );
 				return wp_robots_no_robots( $robots );
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hide-post",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ Just select option "Unlist Post" in any post of any type and that post will be h
 
 == Changelog ==
 = 1.1.5 =
-- Fix: Robots tags conflicting with Yoast SEO.
+- Fix: Compatibility with Yoast SEO's robots tags options. Robots tags from Unlist Posts will override tag changes from Yoast SEO.
 
 = 1.1.4 =
 - Fix: Due to a bug unlisted posts were visible in the search results, which we have fixed now.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: post, unlist posts, hide posts,
 Requires at least: 4.4
 Tested up to: 5.7
-Stable tag: 1.1.4
+Stable tag: 1.1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,8 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 == Changelog ==
+= 1.1.5 =
+- Fix: Robots tags conflicting with Yoast SEO.
 
 = 1.1.4 =
 - Fix: Due to a bug unlisted posts were visible in the search results, which we have fixed now.

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
  * Domain Path:     /languages
- * Version:         1.1.4
+ * Version:         1.1.5
  *
  * @package         Hide_Post
  */
@@ -16,6 +16,6 @@ defined( 'ABSPATH' ) or exit;
 
 define( 'UNLIST_POSTS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UNLIST_POSTS_URI', plugins_url( '/', __FILE__ ) );
-define( 'UNLIST_POSTS_VER', '1.1.4' );
+define( 'UNLIST_POSTS_VER', '1.1.5' );
 
 require_once UNLIST_POSTS_DIR . 'class-unlist-posts.php';


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Fix: Robots tags conflicting with Yoast SEO. (#33)

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Yoast SEO plugin is present on the site and the page is selected to be crawled by Google and the page is also unlisted from our plugin then only add `noindex` and not add both `index` and `noindex`

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
