### PR TITLE
Fix: Unlisted post visible on previous, next post pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** post, unlist posts, hide posts,  
 **Requires at least:** 4.4  
 **Tested up to:** 5.7  
-**Stable tag:** 1.1.5  
+**Stable tag:** 1.1.6 
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -36,6 +36,9 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 ## Changelog ##
+### 1.1.6 ###
+- Fix: Unlisted post visible in preview/next post links.
+
 ### 1.1.5 ###
 - Fix: Compatibility with Yoast SEO's robots tags options. Robots tags from Unlist Posts will override tag changes from Yoast SEO.
 

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -128,7 +128,9 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 
 			// bail if none of the posts are hidden or we are on admin page or singular page.
 			if ( ( is_admin() && ! wp_doing_ajax() ) || in_array( get_the_ID(), $hidden_posts, true ) || empty( $hidden_posts ) ) {
+				if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) {
 				return $where;
+				}
 			}
 
 			$where .= ' AND p.ID NOT IN ( ' . esc_sql( $this->hidden_post_string() ) . ' ) ';
@@ -203,8 +205,10 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 
 			// bail if none of the posts are hidden or we are on admin page or singular page.
 			if ( ( is_admin() && ! wp_doing_ajax() ) || in_array( get_the_ID(), $hidden_posts, true ) || empty( $hidden_posts ) ) {
+				if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) {
 				return $clauses;
 			}
+		}
 
 			$where            = $clauses['where'];
 			$where           .= ' AND comment_post_ID NOT IN ( ' . esc_sql( $this->hidden_post_string() ) . ' ) ';

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -128,8 +128,8 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 
 			// bail if none of the posts are hidden or we are on admin page or singular page.
 			if ( ( is_admin() && ! wp_doing_ajax() ) || in_array( get_the_ID(), $hidden_posts, true ) || empty( $hidden_posts ) ) {
-				if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) {
-				return $where;
+				if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) { // condition run when user already on unlisted post.
+				   return $where;
 				}
 			}
 
@@ -205,10 +205,10 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 
 			// bail if none of the posts are hidden or we are on admin page or singular page.
 			if ( ( is_admin() && ! wp_doing_ajax() ) || in_array( get_the_ID(), $hidden_posts, true ) || empty( $hidden_posts ) ) {
-				if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) {
-				return $clauses;
-			}
-		}
+			    if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) { // condition run when user already on unlisted post.
+			   	  return $clauses;
+			    }
+		    }
 
 			$where            = $clauses['where'];
 			$where           .= ' AND comment_post_ID NOT IN ( ' . esc_sql( $this->hidden_post_string() ) . ' ) ';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hide-post",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: post, unlist posts, hide posts,
 Requires at least: 4.4
 Tested up to: 5.7
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,9 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 == Changelog ==
+= 1.1.6 =
+- Fix: Unlisted post visible in preview/next post links.
+
 = 1.1.5 =
 - Fix: Compatibility with Yoast SEO's robots tags options. Robots tags from Unlist Posts will override tag changes from Yoast SEO.
 

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
  * Domain Path:     /languages
- * Version:         1.1.5
+ * Version:         1.1.6
  *
  * @package         Hide_Post
  */
@@ -16,6 +16,6 @@ defined( 'ABSPATH' ) or exit;
 
 define( 'UNLIST_POSTS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UNLIST_POSTS_URI', plugins_url( '/', __FILE__ ) );
-define( 'UNLIST_POSTS_VER', '1.1.5' );
+define( 'UNLIST_POSTS_VER', '1.1.6' );
 
 require_once UNLIST_POSTS_DIR . 'class-unlist-posts.php';


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Issue - https://wordpress.org/support/topic/previous-post-next-post-links-2/

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Visit the unlisted post and check on clicking on previous and next link unlisted post visible or not.

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
