### PR TITLE
Tests to make sure the unlisted posts are hidden from wp_list_pages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1946,5 +1946,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/tests/test-wp-list-pages.php
+++ b/tests/test-wp-list-pages.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Class TestWPListPagesUnlisted
+ *
+ * @package Unlist_Posts
+ */
+
+/**
+ * Make sure WP_Query does not return the unlisted posts.
+ */
+class TestWPListPagesUnlisted extends WP_UnitTestCase {
+
+	/**
+	 * User ID for a editor user..
+	 *
+	 * @var int
+	 */
+	private $editor_user_id;
+
+	/**
+	 * Setup the tests class.
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		$this->editor_user_id = self::factory()->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+	}
+
+	/**
+	 * Test to make sure unlisted posts are hidden from wp_list_pages_excludes filter.
+	 */
+	public function test_unlisted_post_not_in_wp_list_pages() {
+        _delete_all_posts();
+		wp_set_current_user( $this->editor_user_id );
+
+        // Listed Post.
+		$listed_post   = self::factory()->post->create(
+			array(
+				'post_title' => 'Listed Post Title',
+                'post_type' => 'page'
+			)
+		);
+
+        // Unlisted Post.
+        $unlisted_post = self::factory()->post->create(
+			array(
+				'post_title' => 'Unlisted Post Title',
+                'post_type' => 'page'
+			)
+		);
+        $_POST['unlist_posts']       = true;
+		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
+		Unlist_Posts_Admin::instance()->save_meta( $unlisted_post );
+
+		$list_pages_markup = wp_list_pages(
+            array(
+                'echo' => false,
+            )
+        );
+
+		// Assert that the Unlisted Post is visible in wp_list_page().
+        $this->assertNotContains( 'Unlisted Post Title', $list_pages_markup );
+	}
+
+    /**
+	 * Test to make sure unlisted posts are hidden from wp_list_pages_excludes filter.
+	 */
+	public function test_listed_post_in_wp_list_pages() {
+        _delete_all_posts();
+		wp_set_current_user( $this->editor_user_id );
+
+        // Listed Post.
+		$listed_post   = self::factory()->post->create(
+			array(
+				'post_title' => 'Listed Post Title',
+                'post_type' => 'page'
+			)
+		);
+
+        // Unlisted Post.
+        $unlisted_post = self::factory()->post->create(
+			array(
+				'post_title' => 'Unlisted Post Title',
+                'post_type' => 'page'
+			)
+		);
+        $_POST['unlist_posts']       = true;
+		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
+		Unlist_Posts_Admin::instance()->save_meta( $unlisted_post );
+
+		$list_pages_markup = wp_list_pages(
+            array(
+                'echo' => false,
+            )
+        );
+
+		// Assert that the Listed Post is visible in wp_list_page().
+        $this->assertContains( 'Listed Post Title', $list_pages_markup );
+	}
+}

--- a/tests/test-wp-list-pages.php
+++ b/tests/test-wp-list-pages.php
@@ -11,7 +11,7 @@
 class TestWPListPagesUnlisted extends WP_UnitTestCase {
 
 	/**
-	 * User ID for a editor user..
+	 * User ID for the editor user.
 	 *
 	 * @var int
 	 */

--- a/tests/test-wp-list-pages.php
+++ b/tests/test-wp-list-pages.php
@@ -34,71 +34,71 @@ class TestWPListPagesUnlisted extends WP_UnitTestCase {
 	 * Test to make sure unlisted posts are hidden from wp_list_pages_excludes filter.
 	 */
 	public function test_unlisted_post_not_in_wp_list_pages() {
-        _delete_all_posts();
+		_delete_all_posts();
 		wp_set_current_user( $this->editor_user_id );
 
-        // Listed Post.
-		$listed_post   = self::factory()->post->create(
+		// Listed Post.
+		$listed_post = self::factory()->post->create(
 			array(
 				'post_title' => 'Listed Post Title',
-                'post_type' => 'page'
+				'post_type' => 'page',
 			)
 		);
 
-        // Unlisted Post.
-        $unlisted_post = self::factory()->post->create(
+		// Unlisted Post.
+		$unlisted_post = self::factory()->post->create(
 			array(
 				'post_title' => 'Unlisted Post Title',
-                'post_type' => 'page'
+				'post_type' => 'page',
 			)
 		);
-        $_POST['unlist_posts']       = true;
+		$_POST['unlist_posts']       = true;
 		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
 		Unlist_Posts_Admin::instance()->save_meta( $unlisted_post );
 
 		$list_pages_markup = wp_list_pages(
-            array(
-                'echo' => false,
-            )
-        );
+			array(
+				'echo' => false,
+			)
+		);
 
 		// Assert that the Unlisted Post is visible in wp_list_page().
-        $this->assertNotContains( 'Unlisted Post Title', $list_pages_markup );
+		$this->assertNotContains( 'Unlisted Post Title', $list_pages_markup );
 	}
 
-    /**
+	/**
 	 * Test to make sure unlisted posts are hidden from wp_list_pages_excludes filter.
 	 */
 	public function test_listed_post_in_wp_list_pages() {
-        _delete_all_posts();
+		_delete_all_posts();
 		wp_set_current_user( $this->editor_user_id );
 
-        // Listed Post.
-		$listed_post   = self::factory()->post->create(
+		// Listed Post.
+		$listed_post = self::factory()->post->create(
 			array(
 				'post_title' => 'Listed Post Title',
-                'post_type' => 'page'
+				'post_type' => 'page',
 			)
 		);
 
-        // Unlisted Post.
-        $unlisted_post = self::factory()->post->create(
+		// Unlisted Post.
+		$unlisted_post = self::factory()->post->create(
 			array(
 				'post_title' => 'Unlisted Post Title',
-                'post_type' => 'page'
+				'post_type' => 'page',
 			)
 		);
-        $_POST['unlist_posts']       = true;
+		$_POST['unlist_posts']       = true;
 		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
 		Unlist_Posts_Admin::instance()->save_meta( $unlisted_post );
 
 		$list_pages_markup = wp_list_pages(
-            array(
-                'echo' => false,
-            )
-        );
+			array(
+				'echo' => false,
+			)
+		);
 
 		// Assert that the Listed Post is visible in wp_list_page().
-        $this->assertContains( 'Listed Post Title', $list_pages_markup );
+		$this->assertContains( 'Listed Post Title', $list_pages_markup );
 	}
 }


### PR DESCRIPTION
### Description
Added tests to make sure the unlisted posts are hidden from wp_list_pages
Solves https://github.com/brainstormforce/unlist-posts/issues/62

### How has this been tested?
composer run tests

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
