### PR TITLE
Breaking: Show comments for a unlisted posts

### DIFF
--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -64,7 +64,6 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			add_action( 'wp_head', array( $this, 'hide_post_from_searchengines' ) );
 			add_filter( 'wp_robots', array( $this, 'no_robots_for_unlisted_posts' ) );
 			add_filter( 'rank_math/frontend/robots', array( $this, 'change_robots_for_rankmath' ) );
-			add_filter( 'comments_clauses', array( $this, 'comments_clauses' ), 20, 2 );
 			add_filter( 'wp_list_pages_excludes', array( $this, 'wp_list_pages_excludes' ) );
 		}
 
@@ -203,37 +202,6 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			}
 
 			return $robots;
-		}
-
-		/**
-		 * Filter where clause to hide selected posts.
-		 *
-		 * @since  1.0.1
-		 *
-		 * @param  Array    $clauses Comment Query Clauses.
-		 * @param  WP_Query $query WP_Query &$this The WP_Query instance (passed by reference).
-		 *
-		 * @return String $where Where clause.
-		 */
-		public function comments_clauses( $clauses, $query ) {
-
-			// Bail if posts unlists is disabled.
-			if ( false === $this->allow_post_unlist() ) {
-				return $clauses;
-			}
-
-			$hidden_posts = get_option( 'unlist_posts', array() );
-
-			// bail if none of the posts are hidden or we are on admin page or singular page.
-			if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) {
-				return $clauses;
-			}
-
-			$where            = $clauses['where'];
-			$where           .= ' AND comment_post_ID NOT IN ( ' . esc_sql( $this->hidden_post_string() ) . ' ) ';
-			$clauses['where'] = $where;
-
-			return $clauses;
 		}
 
 		/**

--- a/tests/test-comments-unlisted-post.php
+++ b/tests/test-comments-unlisted-post.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class CommentsUnlistedPost
+ *
+ * @package Unlist_Posts
+ */
+
+/**
+ * Make sure unlisted posts are hidden from get_adjacent_post().
+ */
+class CommentsUnlistedPost extends WP_UnitTestCase {
+	/**
+	 * Test that posts of an unlisted comment are shown.
+	 */
+	public function test_comments_unlisted_post() {
+		$editor_user_id = self::factory()->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+
+		wp_set_current_user( $editor_user_id );
+
+		// Create an listed post.
+		$listed_post = self::factory()->post->create();
+
+		// Add comments for the post.
+		$comment_ids = array();
+		for ( $i = 0; $i < 5; $i++ ) {
+			$comment_ids[] = self::factory()->comment->create(
+				array(
+					'comment_post_ID' => $listed_post,
+				)
+			);
+		}
+
+		// Set the post as unlisted.
+		$_POST['unlist_posts']       = true;
+		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
+		Unlist_Posts_Admin::instance()->save_meta( $listed_post );
+
+		// Get comments for the post.
+		$comments = get_comments(
+			array(
+				'post_id' => $listed_post,
+			)
+		);
+
+		$this->assertCount( 5, $comments );
+	}
+}


### PR DESCRIPTION
### Description
Since the begnning of the plugin, comments of the unlisted posts are not displayed. which is not accurate as comments should be displayed regardless the post is listed or unlisted

Fixes #89

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Breaking change

### How has this been tested?
PHPUnit test case

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
