### PR TITLE
Feature: Checkbox to allow / disallow robots to index

### DIFF
--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -75,58 +75,12 @@ class Unlist_Posts_Admin {
 	 * @param  POST $post Currennt post object which is being displayed.
 	 */
 	function metabox_render( $post ) {
-
-		$hidden_posts = get_option( 'unlist_posts', array() );
-
-		if ( '' === $hidden_posts ) {
-			$hidden_posts = array();
-		}
-
-		$checked = '';
-
-		if ( in_array( (int) $post->ID, $hidden_posts, true ) ) {
-			$checked = 'checked';
-		}
-
-		// We'll use this nonce field later on when saving.
-		wp_nonce_field( 'unlist_post_nounce', 'unlist_post_nounce' );
-		?>
-		<p>
-			<label class="checkbox-inline">
-				<input name="unlist_posts" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php esc_html_e( 'Unlist this post?', 'unlist-posts' ); ?>
-			</label>
-		</p>
-		<p class="description"><?php esc_html_e( 'This will hide the post from your site, The post can only be accessed from direct URL.', 'unlist-posts' ); ?> </p>
-		
-		
-		<?php
-		// Enable Robots
-		$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
-
-		if ( '' === $enable_robots ) {
-			$enable_robots = array();
-		}
-
-		$checked = '';
-
-		if ( in_array( (int) $post->ID, $enable_robots, true ) ) {
-			$checked = 'checked';
-		}
-
-		// We'll use this nonce field later on when saving.
-		wp_nonce_field( 'unlist_post_enable_robots_nounce', 'unlist_post_enable_robots_nounce' );
-		?>
-		<p>
-			<label class="checkbox-inline">
-				<input name="unlist_posts_enable_robots" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php esc_html_e( 'Allow Robots to Crawl?', 'unlist-posts' ); ?>
-			</label>
-		</p>
-		<p class="description"><?php esc_html_e( 'By default, Unlist Posts does not allow indexing of unlisted posts, check this box to enable indexing.', 'unlist-posts' ); ?> </p>
-		<?php
+		$this->render_unlist_posts( $post );
+		$this->render_enable_robots( $post );
 	}
 
 	/**
-	 * Save meta field.
+	 * Save meta field for unlist posts.
 	 *
 	 * @param  POST $post_id Currennt post object which is being displayed.
 	 *
@@ -177,7 +131,7 @@ class Unlist_Posts_Admin {
 	}
 
 	/**
-	 * Save meta field.
+	 * Save meta field for enable robots.
 	 *
 	 * @param  POST $post_id Currennt post object which is being displayed.
 	 *
@@ -331,6 +285,68 @@ class Unlist_Posts_Admin {
 		}
 
 		return $query;
+	}
+	
+	/**
+	 * Render Unlist Posts meta field
+	 *
+	 * @param Post  $post     The current post object.
+	 * @return void
+	 */
+	function render_unlist_posts( $post ) {
+		$hidden_posts = get_option( 'unlist_posts', array() );
+
+		if ( '' === $hidden_posts ) {
+			$hidden_posts = array();
+		}
+
+		$checked = '';
+
+		if ( in_array( (int) $post->ID, $hidden_posts, true ) ) {
+			$checked = 'checked';
+		}
+
+		// We'll use this nonce field later on when saving.
+		wp_nonce_field( 'unlist_post_nounce', 'unlist_post_nounce' );
+		?>
+		<p>
+			<label class="checkbox-inline">
+				<input name="unlist_posts" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php esc_html_e( 'Unlist this post?', 'unlist-posts' ); ?>
+			</label>
+		</p>
+		<p class="description"><?php esc_html_e( 'This will hide the post from your site, The post can only be accessed from direct URL.', 'unlist-posts' ); ?> </p>
+		<?php
+	}
+	
+	/**
+	 * Render enable robots meta field
+	 *
+	 * @param Post  $post     The current post object.
+	 * @return void
+	 */
+	function render_enable_robots( $post ) {
+		$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
+
+		if ( '' === $enable_robots ) {
+			$enable_robots = array();
+		}
+
+		$checked = '';
+
+		if ( in_array( (int) $post->ID, $enable_robots, true ) ) {
+			$checked = 'checked';
+		}
+
+		// We'll use this nonce field later on when saving.
+		wp_nonce_field( 'unlist_post_enable_robots_nounce', 'unlist_post_enable_robots_nounce' );
+		?>
+		<p>
+			<label class="checkbox-inline">
+				<input name="unlist_posts_enable_robots" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php esc_html_e( 'Allow Robots to Crawl?', 'unlist-posts' ); ?>
+			</label>
+		</p>
+		<p class="description"><?php esc_html_e( 'By default, Unlist Posts does not allow indexing of unlisted posts, check this box to enable indexing.', 'unlist-posts' ); ?> </p>
+		<?php
 	}
 
 }

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -40,6 +40,7 @@ class Unlist_Posts_Admin {
 	private function __construct() {
 		add_action( 'add_meta_boxes', array( $this, 'register_metabox' ) );
 		add_action( 'save_post', array( $this, 'save_meta' ) );
+		add_action( 'save_post', array( $this, 'save_meta_enable_robots' ) );
 		add_filter( 'display_post_states', array( $this, 'add_unlisted_post_status' ), 10, 2 );
 		add_filter( 'parse_query', array( $this, 'filter_unlisted_posts' ) );
 		add_action( 'init', array( $this, 'add_post_filter' ) );
@@ -96,6 +97,31 @@ class Unlist_Posts_Admin {
 			</label>
 		</p>
 		<p class="description"><?php esc_html_e( 'This will hide the post from your site, The post can only be accessed from direct URL.', 'unlist-posts' ); ?> </p>
+		
+		
+		<?php
+		// Enable Robots
+		$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
+
+		if ( '' === $enable_robots ) {
+			$enable_robots = array();
+		}
+
+		$checked = '';
+
+		if ( in_array( (int) $post->ID, $enable_robots, true ) ) {
+			$checked = 'checked';
+		}
+
+		// We'll use this nonce field later on when saving.
+		wp_nonce_field( 'unlist_post_enable_robots_nounce', 'unlist_post_enable_robots_nounce' );
+		?>
+		<p>
+			<label class="checkbox-inline">
+				<input name="unlist_posts_enable_robots" type="checkbox" <?php echo esc_attr( $checked ); ?> value=""><?php esc_html_e( 'Allow Robots to Crawl?', 'unlist-posts' ); ?>
+			</label>
+		</p>
+		<p class="description"><?php esc_html_e( 'By default, Unlist Posts does not allow indexing of unlisted posts, check this box to enable indexing.', 'unlist-posts' ); ?> </p>
 		<?php
 	}
 
@@ -148,6 +174,57 @@ class Unlist_Posts_Admin {
 		}
 
 		update_option( 'unlist_posts', $hidden_posts );
+	}
+
+	/**
+	 * Save meta field.
+	 *
+	 * @param  POST $post_id Currennt post object which is being displayed.
+	 *
+	 * @return Void
+	 */
+	public function save_meta_enable_robots( $post_id ) {
+		// Bail if we're doing an auto save.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		// if our nonce isn't there, or we can't verify it, bail.
+		if ( ! isset( $_POST['unlist_post_enable_robots_nounce'] ) || ! wp_verify_nonce( $_POST['unlist_post_enable_robots_nounce'], 'unlist_post_enable_robots_nounce' ) ) {
+			return;
+		}
+
+		// if our current user can't edit this post, bail.
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		// Don't record unlist option for revisions.
+		if ( false !== wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
+
+		if ( '' === $enable_robots ) {
+			$enable_robots = array();
+		}
+
+		if ( isset( $_POST['unlist_posts_enable_robots'] ) ) {
+			$enable_robots[] = $post_id;
+
+			// Get only the unique post id's in the option array.
+			$enable_robots = array_unique( $enable_robots );
+		} elseif ( in_array( $post_id, $enable_robots, true ) ) {
+
+			// Get only the unique post id's in the option array.
+			$enable_robots = array_unique( $enable_robots );
+
+			$key = array_search( $post_id, $enable_robots, true );
+			unset( $enable_robots[ $key ] );
+		}
+
+		update_option( 'unlist_posts_enable_robots', $enable_robots );
 	}
 
 	/**

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -94,9 +94,12 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			}
 
 			$hidden_posts = get_option( 'unlist_posts', array() );
+			$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
 
 			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				$robots['index'] = 'noindex';
+				if ( !in_array( get_the_ID(), $enable_robots, true ) && false !== get_the_ID()) {
+					$robots['index'] = 'noindex';
+				}
 			}
 			return $robots;
 		}
@@ -175,9 +178,12 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			}
 
 			$hidden_posts = get_option( 'unlist_posts', array() );
+			$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
 
 			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				wp_no_robots();
+				if ( !in_array( get_the_ID(), $enable_robots, true ) && false !== get_the_ID()) {
+					wp_no_robots();
+				}
 			}
 		}
 
@@ -194,11 +200,14 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			}
 
 			$hidden_posts = get_option( 'unlist_posts', array() );
+			$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
 
 			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				// Disable robots tags from Yoast SEO.
-				add_filter( 'wpseo_robots_array', '__return_empty_array' );
-				return wp_robots_no_robots( $robots );
+				if ( !in_array( get_the_ID(), $enable_robots, true ) && false !== get_the_ID()) {
+					// Disable robots tags from Yoast SEO.
+					add_filter( 'wpseo_robots_array', '__return_empty_array' );
+					return wp_robots_no_robots( $robots );
+				}
 			}
 
 			return $robots;

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -96,10 +96,8 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 			$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
 
-			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				if ( !in_array( get_the_ID(), $enable_robots, true ) && false !== get_the_ID()) {
-					$robots['index'] = 'noindex';
-				}
+			if ( $this->robots_enabled_check( $hidden_posts, $enable_robots ) ) {
+				$robots['index'] = 'noindex';
 			}
 			return $robots;
 		}
@@ -180,10 +178,8 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 			$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
 
-			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				if ( !in_array( get_the_ID(), $enable_robots, true ) && false !== get_the_ID()) {
-					wp_no_robots();
-				}
+			if ( $this->robots_enabled_check( $hidden_posts, $enable_robots ) ) {
+				wp_no_robots();
 			}
 		}
 
@@ -202,12 +198,10 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 			$enable_robots = get_option( 'unlist_posts_enable_robots', array() );
 
-			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				if ( !in_array( get_the_ID(), $enable_robots, true ) && false !== get_the_ID()) {
-					// Disable robots tags from Yoast SEO.
-					add_filter( 'wpseo_robots_array', '__return_empty_array' );
-					return wp_robots_no_robots( $robots );
-				}
+			if ( $this->robots_enabled_check( $hidden_posts, $enable_robots ) ) {
+				// Disable robots tags from Yoast SEO.
+				add_filter( 'wpseo_robots_array', '__return_empty_array' );
+				return wp_robots_no_robots( $robots );
 			}
 
 			return $robots;
@@ -254,6 +248,25 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 		 */
 		private function allow_post_unlist() {
 			return apply_filters( 'unlist_posts_enabled', true );
+		}
+		
+		/**
+		 * Check if robots should be enabled
+		 *
+		 * @param  array $hidden_posts  Array of hidden post ids.
+		 * @param  array $enable_robots Array of post ids that should allow robots
+		 * @return boolean False - This is the default value. This means that robots are disabled.
+		 */
+		private function robots_enabled_check( $hidden_posts, $enable_robots ) {
+			// Check if hidden posts for post id is enabled
+			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
+				// Check if enable robots for post id is enabled
+				if ( !in_array( get_the_ID(), $enable_robots, true ) && false !== get_the_ID() ) {
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 	}


### PR DESCRIPTION
### Description
Added the ability to set noindex or index via a checkbox below the existing meta box field

### Screenshots
![image](https://github.com/brainstormforce/unlist-posts/assets/40912852/17ec73c5-e652-4f91-a8be-befea10ed75c)

### Types of changes
New feature

### How has this been tested?
Checked the box, viewed source code for unlisted page, saw it allowed indexing. Unchecked the box, viewed source code, saw it had noindex again. Repeated process for published pages.

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests (It does not appear the configuration in this repo is set properly for this)
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
