### PR TITLE
Release 1.2.0 — WordPress 7.0 compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         wordpress: ['7.0']
 
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -56,7 +56,7 @@ jobs:
           git clone --depth 1 --branch "$WP_VERSION" https://github.com/WordPress/wordpress-develop.git /tmp/wp-develop 2>/dev/null \
             || git clone --depth 1 --branch "${WP_VERSION}.0" https://github.com/WordPress/wordpress-develop.git /tmp/wp-develop 2>/dev/null \
             || git clone --depth 1 https://github.com/WordPress/wordpress-develop.git /tmp/wp-develop
-          echo "WP_PHPUNIT__DIR=/tmp/wp-develop/tests/phpunit" >> "$GITHUB_ENV"
+          echo "WP_PHPUNIT__DIR_OVERRIDE=/tmp/wp-develop/tests/phpunit" >> "$GITHUB_ENV"
 
       - name: Run tests
         run: composer run test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -47,5 +47,16 @@ jobs:
       - name: Setup problem matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Fetch WP test scaffolding matching installed core
+        run: |
+          WP_VERSION=$(php -r "include 'wordpress/wp-includes/version.php'; echo \$wp_version;")
+          echo "Installed WP core: $WP_VERSION"
+          # Try exact tag (e.g. 7.0.1), then dotted-zero form (e.g. 7.0 -> 7.0.0),
+          # then fall back to trunk (covers RC/beta where no matching tag exists).
+          git clone --depth 1 --branch "$WP_VERSION" https://github.com/WordPress/wordpress-develop.git /tmp/wp-develop 2>/dev/null \
+            || git clone --depth 1 --branch "${WP_VERSION}.0" https://github.com/WordPress/wordpress-develop.git /tmp/wp-develop 2>/dev/null \
+            || git clone --depth 1 https://github.com/WordPress/wordpress-develop.git /tmp/wp-develop
+          echo "WP_PHPUNIT__DIR=/tmp/wp-develop/tests/phpunit" >> "$GITHUB_ENV"
+
       - name: Run tests
         run: composer run test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4']
-        wordpress: ['6.9']
+        wordpress: ['7.0']
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 **Tags:** post, unlist posts, hide posts,
 **Requires at least:** 4.6
 **Tested up to:** 7.0
-**Requires PHP:** 7.4
-**Stable tag:** 1.2.0
+**Stable tag:** 1.1.9
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,10 +37,6 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 ## Changelog ##
-
-### 1.2.0 ###
-- Compatibility: Tested up to WordPress 7.0.
-- Improvement: Added minimum PHP version requirement of 7.4 to match WordPress 7.0.
 
 ### 1.1.9 ###
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unlist Posts & Pages #
 **Contributors:** [nikschavan](https://profiles.wordpress.org/nikschavan/)
 **Tags:** post, unlist posts, hide posts,
-**Requires at least:** 5.7
+**Requires at least:** 4.6
 **Tested up to:** 7.0
 **Requires PHP:** 7.4
 **Stable tag:** 1.2.0
@@ -41,9 +41,7 @@ Just select option "Unlist Post" in any post of any type and that post will be h
 
 ### 1.2.0 ###
 - Compatibility: Tested up to WordPress 7.0.
-- Improvement: Bumped minimum WordPress version to 5.7.
 - Improvement: Added minimum PHP version requirement of 7.4 to match WordPress 7.0.
-- Removed: Deprecated `wp_no_robots()` fallback for WordPress versions older than 5.7.
 
 ### 1.1.9 ###
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** post, unlist posts, hide posts,
 **Requires at least:** 4.6
 **Tested up to:** 7.0
-**Stable tag:** 1.1.9
+**Stable tag:** 1.2.0
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,9 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 ## Changelog ##
+
+### 1.2.0 ###
+- Compatibility: Tested up to WordPress 7.0.
 
 ### 1.1.9 ###
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Unlist Posts & Pages #
 **Contributors:** [nikschavan](https://profiles.wordpress.org/nikschavan/)
 **Tags:** post, unlist posts, hide posts,
-**Requires at least:** 4.6
-**Tested up to:** 6.9
-**Stable tag:** 1.1.9
+**Requires at least:** 5.7
+**Tested up to:** 7.0
+**Requires PHP:** 7.4
+**Stable tag:** 1.2.0
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +38,12 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 ## Changelog ##
+
+### 1.2.0 ###
+- Compatibility: Tested up to WordPress 7.0.
+- Improvement: Bumped minimum WordPress version to 5.7.
+- Improvement: Added minimum PHP version requirement of 7.4 to match WordPress 7.0.
+- Removed: Deprecated `wp_no_robots()` fallback for WordPress versions older than 5.7.
 
 ### 1.1.9 ###
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Just select option "Unlist Post" in any post of any type and that post will be h
 ## Changelog ##
 
 ### 1.2.0 ###
+- New: Quick Edit and Bulk Edit support to unlist or list posts directly from the post list table, plus a new "Unlisted" column on public post types.
+- Fix: Unlisted posts are now visible in admin-originated AJAX requests, restoring compatibility with plugins like LearnDash that query posts via AJAX from the admin.
 - Compatibility: Tested up to WordPress 7.0.
 
 ### 1.1.9 ###

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -61,6 +61,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			add_filter( 'posts_where', array( $this, 'where_clause' ), 20, 2 );
 			add_filter( 'get_next_post_where', array( $this, 'post_navigation_clause' ), 20, 1 );
 			add_filter( 'get_previous_post_where', array( $this, 'post_navigation_clause' ), 20, 1 );
+			add_action( 'wp_head', array( $this, 'hide_post_from_searchengines' ) );
 			add_filter( 'wp_robots', array( $this, 'no_robots_for_unlisted_posts' ) );
 			add_filter( 'rank_math/frontend/robots', array( $this, 'change_robots_for_rankmath' ) );
 			add_filter( 'wp_list_pages_excludes', array( $this, 'wp_list_pages_excludes' ) );
@@ -153,6 +154,30 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$where .= ' AND p.ID NOT IN ( ' . esc_sql( $this->hidden_post_string() ) . ' ) ';
 
 			return $where;
+		}
+
+		/**
+		 * Add meta tags to block search engines on a page if the page is unlisted.
+		 *
+		 * @since  1.0.1
+		 */
+		public function hide_post_from_searchengines() {
+
+			// wp_no_robots is deprecated since WP 5.7.
+			if ( function_exists( 'wp_robots_no_robots' ) ) {
+				return;
+			}
+
+			// Bail if posts unlists is disabled.
+			if ( false === $this->allow_post_unlist() ) {
+				return false;
+			}
+
+			$hidden_posts = get_option( 'unlist_posts', array() );
+
+			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
+				wp_no_robots();
+			}
 		}
 
 		/**

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -61,7 +61,6 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			add_filter( 'posts_where', array( $this, 'where_clause' ), 20, 2 );
 			add_filter( 'get_next_post_where', array( $this, 'post_navigation_clause' ), 20, 1 );
 			add_filter( 'get_previous_post_where', array( $this, 'post_navigation_clause' ), 20, 1 );
-			add_action( 'wp_head', array( $this, 'hide_post_from_searchengines' ) );
 			add_filter( 'wp_robots', array( $this, 'no_robots_for_unlisted_posts' ) );
 			add_filter( 'rank_math/frontend/robots', array( $this, 'change_robots_for_rankmath' ) );
 			add_filter( 'wp_list_pages_excludes', array( $this, 'wp_list_pages_excludes' ) );
@@ -154,30 +153,6 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$where .= ' AND p.ID NOT IN ( ' . esc_sql( $this->hidden_post_string() ) . ' ) ';
 
 			return $where;
-		}
-
-		/**
-		 * Add meta tags to block search engines on a page if the page is unlisted.
-		 *
-		 * @since  1.0.1
-		 */
-		public function hide_post_from_searchengines() {
-
-			// wp_no_robots is deprecated since WP 5.7.
-			if ( function_exists( 'wp_robots_no_robots' ) ) {
-				return;
-			}
-
-			// Bail if posts unlists is disabled.
-			if ( false === $this->allow_post_unlist() ) {
-				return false;
-			}
-
-			$hidden_posts = get_option( 'unlist_posts', array() );
-
-			if ( in_array( get_the_ID(), $hidden_posts, true ) && false !== get_the_ID() ) {
-				wp_no_robots();
-			}
 		}
 
 		/**

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
     "phpcompatibility/php-compatibility": "^9.3",
     "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^9.5",
-    "roots/wordpress": "^6.9",
+    "roots/wordpress-full": "^7.0@RC",
     "wp-coding-standards/wpcs": "^3.3",
     "wp-phpunit/wp-phpunit": "^6.0",
     "yoast/phpunit-polyfills": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
     "phpcompatibility/php-compatibility": "^9.3",
     "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^9.5",
-    "roots/wordpress-full": "^7.0@RC",
+    "roots/wordpress-full": "*@beta",
     "wp-coding-standards/wpcs": "^3.3",
     "wp-phpunit/wp-phpunit": "^6.0",
     "yoast/phpunit-polyfills": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
     "phpcompatibility/php-compatibility": "^9.3",
     "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^9.5",
+    "roots/wordpress-core-installer": "^3.0",
     "roots/wordpress-full": "*@beta",
     "wp-coding-standards/wpcs": "^3.3",
     "wp-phpunit/wp-phpunit": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea99d0c410db5b269cbf18e525b02989",
+    "content-hash": "a7c3609901a3b1ac6ccddecf9f71bd8b",
     "packages": [],
     "packages-dev": [
         {
@@ -1075,6 +1075,73 @@
                 }
             ],
             "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "roots/wordpress-core-installer",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roots/wordpress-core-installer.git",
+                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
+                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=7.2.24"
+            },
+            "conflict": {
+                "composer/installers": "<1.0.6"
+            },
+            "replace": {
+                "johnpbloch/wordpress-core-installer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0 || ^2.0",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Roots\\Composer\\WordPressCorePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Roots\\Composer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "John P. Bloch",
+                    "email": "me@johnpbloch.com"
+                },
+                {
+                    "name": "Roots",
+                    "email": "team@roots.io"
+                }
+            ],
+            "description": "A Composer custom installer to handle installing WordPress as a dependency",
+            "keywords": [
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/roots/wordpress-core-installer/issues",
+                "source": "https://github.com/roots/wordpress-core-installer/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/roots",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-23T18:47:25+00:00"
         },
         {
             "name": "roots/wordpress-full",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13b4daad92e2fd80d134cba4456a4ca4",
+    "content-hash": "ea99d0c410db5b269cbf18e525b02989",
     "packages": [],
     "packages-dev": [
         {
@@ -1077,134 +1077,24 @@
             "time": "2026-01-27T05:45:00+00:00"
         },
         {
-            "name": "roots/wordpress",
-            "version": "6.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/roots/wordpress.git",
-                "reference": "29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress/zipball/29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45",
-                "reference": "29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45",
-                "shasum": ""
-            },
-            "require": {
-                "roots/wordpress-core-installer": "^3.0",
-                "roots/wordpress-no-content": "self.version"
-            },
-            "type": "metapackage",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT",
-                "GPL-2.0-or-later"
-            ],
-            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
-            "homepage": "https://wordpress.org/",
-            "keywords": [
-                "blog",
-                "cms",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/roots/wordpress/issues",
-                "source": "https://github.com/roots/wordpress/tree/6.9"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/roots",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-05-23T18:54:22+00:00"
-        },
-        {
-            "name": "roots/wordpress-core-installer",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/roots/wordpress-core-installer.git",
-                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
-                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=7.2.24"
-            },
-            "conflict": {
-                "composer/installers": "<1.0.6"
-            },
-            "replace": {
-                "johnpbloch/wordpress-core-installer": "*"
-            },
-            "require-dev": {
-                "composer/composer": "^1.0 || ^2.0",
-                "phpunit/phpunit": "^8.5"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Roots\\Composer\\WordPressCorePlugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Roots\\Composer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "John P. Bloch",
-                    "email": "me@johnpbloch.com"
-                },
-                {
-                    "name": "Roots",
-                    "email": "team@roots.io"
-                }
-            ],
-            "description": "A Composer custom installer to handle installing WordPress as a dependency",
-            "keywords": [
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/roots/wordpress-core-installer/issues",
-                "source": "https://github.com/roots/wordpress-core-installer/tree/3.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/roots",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-05-23T18:47:25+00:00"
-        },
-        {
-            "name": "roots/wordpress-no-content",
-            "version": "6.9",
+            "name": "roots/wordpress-full",
+            "version": "7.0-RC3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "6.9"
+                "reference": "master"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/release/wordpress-6.9-no-content.zip",
-                "reference": "6.9",
-                "shasum": "2d8cb4b253b690e255afde1d451e87380e6a5cb5"
+                "url": "https://downloads.wordpress.org/release/wordpress-7.0-RC3.zip",
+                "reference": "master",
+                "shasum": "134ff53d8e5560cbb46203e004390f4bc782dd81"
             },
             "require": {
-                "php": ">= 7.2.24"
+                "php": ">= 7.4"
             },
             "provide": {
-                "wordpress/core-implementation": "6.9"
+                "wordpress/core-implementation": "7.0-RC3"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -1255,7 +1145,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2025-12-02T19:09:36+00:00"
+            "time": "2026-05-08T17:48:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2577,7 +2467,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "roots/wordpress-full": 10
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="7.4-8.2"/>
 
 	<rule ref="WordPress-Core" >
  		<!-- Double arrow alignment requirement adds unwanted changes if you add/remove any parameter from the array -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.4-8.2"/>
+	<config name="testVersion" value="5.4-8.2"/>
 
 	<rule ref="WordPress-Core" >
  		<!-- Double arrow alignment requirement adds unwanted changes if you add/remove any parameter from the array -->

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,8 @@ Just select option "Unlist Post" in any post of any type and that post will be h
 == Changelog ==
 
 = 1.2.0 =
+- New: Quick Edit and Bulk Edit support to unlist or list posts directly from the post list table, plus a new "Unlisted" column on public post types.
+- Fix: Unlisted posts are now visible in admin-originated AJAX requests, restoring compatibility with plugins like LearnDash that query posts via AJAX from the admin.
 - Compatibility: Tested up to WordPress 7.0.
 
 = 1.1.9 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,7 @@ Contributors: Nikschavan
 Tags: post, unlist posts, hide posts,
 Requires at least: 4.6
 Tested up to: 7.0
-Requires PHP: 7.4
-Stable tag: 1.2.0
+Stable tag: 1.1.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,10 +37,6 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 == Changelog ==
-
-= 1.2.0 =
-- Compatibility: Tested up to WordPress 7.0.
-- Improvement: Added minimum PHP version requirement of 7.4 to match WordPress 7.0.
 
 = 1.1.9 =
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Unlist Posts & Pages ===
 Contributors: Nikschavan
 Tags: post, unlist posts, hide posts,
-Requires at least: 5.7
+Requires at least: 4.6
 Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 1.2.0
@@ -41,9 +41,7 @@ Just select option "Unlist Post" in any post of any type and that post will be h
 
 = 1.2.0 =
 - Compatibility: Tested up to WordPress 7.0.
-- Improvement: Bumped minimum WordPress version to 5.7.
 - Improvement: Added minimum PHP version requirement of 7.4 to match WordPress 7.0.
-- Removed: Deprecated `wp_no_robots()` fallback for WordPress versions older than 5.7.
 
 = 1.1.9 =
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Nikschavan
 Tags: post, unlist posts, hide posts,
 Requires at least: 4.6
 Tested up to: 7.0
-Stable tag: 1.1.9
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,9 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 == Changelog ==
+
+= 1.2.0 =
+- Compatibility: Tested up to WordPress 7.0.
 
 = 1.1.9 =
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === Unlist Posts & Pages ===
 Contributors: Nikschavan
 Tags: post, unlist posts, hide posts,
-Requires at least: 4.6
-Tested up to: 6.9
-Stable tag: 1.1.9
+Requires at least: 5.7
+Tested up to: 7.0
+Requires PHP: 7.4
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +38,12 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 == Changelog ==
+
+= 1.2.0 =
+- Compatibility: Tested up to WordPress 7.0.
+- Improvement: Bumped minimum WordPress version to 5.7.
+- Improvement: Added minimum PHP version requirement of 7.4 to match WordPress 7.0.
+- Removed: Deprecated `wp_no_robots()` fallback for WordPress versions older than 5.7.
 
 = 1.1.9 =
 - Improvement: Comments for unlisted posts were hidden, These should be displayed now.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,10 @@ require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 $wp_phpunit_override = getenv( 'WP_PHPUNIT__DIR_OVERRIDE' );
 if ( $wp_phpunit_override ) {
 	putenv( 'WP_PHPUNIT__DIR=' . $wp_phpunit_override );
+	// The wordpress-develop checkout has no wp-tests-config.php shim
+	// (only wp-tests-config-sample.php). Point WP's bootstrap directly
+	// at our config via the constant it respects.
+	define( 'WP_TESTS_CONFIG_FILE_PATH', __DIR__ . '/wp-config.php' );
 }
 
 // Give access to tests_add_filter() function.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,15 @@
 // Composer autoloader must be loaded before WP_PHPUNIT__DIR will be available
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
+// Allow overriding the wp-phpunit dir post-autoload — wp-phpunit's
+// composer autoload sets WP_PHPUNIT__DIR to its locked version, which can
+// lag the WordPress core under test. CI uses this to point at a matching
+// wordpress-develop checkout.
+$wp_phpunit_override = getenv( 'WP_PHPUNIT__DIR_OVERRIDE' );
+if ( $wp_phpunit_override ) {
+	putenv( 'WP_PHPUNIT__DIR=' . $wp_phpunit_override );
+}
+
 // Give access to tests_add_filter() function.
 require_once getenv( 'WP_PHPUNIT__DIR' ) . '/includes/functions.php';
 

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -6,7 +6,7 @@
  * Author:          Nikhil Chavan
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
- * Version:         1.1.9
+ * Version:         1.2.0
  *
  * @package         Hide_Post
  */
@@ -15,6 +15,6 @@ defined( 'ABSPATH' ) or exit;
 
 define( 'UNLIST_POSTS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UNLIST_POSTS_URI', plugins_url( '/', __FILE__ ) );
-define( 'UNLIST_POSTS_VER', '1.1.9' );
+define( 'UNLIST_POSTS_VER', '1.2.0' );
 
 require_once UNLIST_POSTS_DIR . 'class-unlist-posts.php';

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -6,9 +6,7 @@
  * Author:          Nikhil Chavan
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
- * Version:         1.2.0
- * Requires at least: 4.6
- * Requires PHP:      7.4
+ * Version:         1.1.9
  *
  * @package         Hide_Post
  */
@@ -17,6 +15,6 @@ defined( 'ABSPATH' ) or exit;
 
 define( 'UNLIST_POSTS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UNLIST_POSTS_URI', plugins_url( '/', __FILE__ ) );
-define( 'UNLIST_POSTS_VER', '1.2.0' );
+define( 'UNLIST_POSTS_VER', '1.1.9' );
 
 require_once UNLIST_POSTS_DIR . 'class-unlist-posts.php';

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -6,7 +6,9 @@
  * Author:          Nikhil Chavan
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
- * Version:         1.1.9
+ * Version:         1.2.0
+ * Requires at least: 5.7
+ * Requires PHP:      7.4
  *
  * @package         Hide_Post
  */
@@ -15,6 +17,6 @@ defined( 'ABSPATH' ) or exit;
 
 define( 'UNLIST_POSTS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UNLIST_POSTS_URI', plugins_url( '/', __FILE__ ) );
-define( 'UNLIST_POSTS_VER', '1.1.9' );
+define( 'UNLIST_POSTS_VER', '1.2.0' );
 
 require_once UNLIST_POSTS_DIR . 'class-unlist-posts.php';

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -7,7 +7,7 @@
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
  * Version:         1.2.0
- * Requires at least: 5.7
+ * Requires at least: 4.6
  * Requires PHP:      7.4
  *
  * @package         Hide_Post


### PR DESCRIPTION
## Summary
Releases plugin version 1.2.0, declaring compatibility with WordPress 7.0 and shipping features merged to `master` since 1.1.9.

## Changes
- Bump plugin version `1.1.9` → `1.2.0` (in `unlist-posts.php`, `readme.txt`, `README.md`).
- Bump `Tested up to: 7.0` in `readme.txt` / `README.md`.
- Add 1.2.0 changelog entry covering:
  - Quick Edit / Bulk Edit support and new "Unlisted" column (#141)
  - Admin AJAX visibility fix for LearnDash and similar plugins (#138)
- Switch composer dev dep from `roots/wordpress: ^6.9` to `roots/wordpress-full: *@beta` (+ `roots/wordpress-core-installer: ^3.0`) so CI can test against WP 7.0 release candidates and roll forward to stable automatically when published.
- Bump PHPCS `testVersion` to `5.4-8.2` — keeps the historical PHP 5.4 floor while adding PHP 8.2 lint coverage.
- Expand PHPUnit CI matrix from `['7.4']` to `['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']`.

## Not in scope
- No raise to minimum WordPress or PHP version. `Requires at least` / `Requires PHP` headers remain unset; the `wp_no_robots()` fallback is intentionally kept for older WP installs.

## Test plan
- [x] PHPCS passes against PHP 5.4-8.2 testVersion on all plugin runtime files.
- [ ] PHPUnit passes on the new 6-version matrix (PHP 7.4 – 8.4) against WP 7.0-RC3.
- [x] Plugin loads and core features work in a local Studio site running WordPress 7.0.
