### PR TITLE
Show unlisted posts in admin AJAX requests

### DIFF
--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -240,7 +240,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 		/**
 		 * Check if the current AJAX request originated from an admin page.
 		 *
-		 * @since  1.2.0
+		 * @since  1.1.10
 		 * @return boolean True if the AJAX request referer is an admin page.
 		 */
 		private function is_admin_referer() {

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 
 			// bail if none of the posts are hidden or we are on admin page or singular page.
-			if ( ( is_admin() && ! wp_doing_ajax() ) || $query->is_singular || empty( $hidden_posts ) ) {
+			if ( ( is_admin() && ( ! wp_doing_ajax() || $this->is_admin_referer() ) ) || $query->is_singular || empty( $hidden_posts ) ) {
 				return $where;
 			}
 
@@ -148,7 +148,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 
 			// bail if none of the posts are hidden or we are on admin page or singular page.
-			if ( ( is_admin() && ! wp_doing_ajax() ) || empty( $hidden_posts ) ) {
+			if ( ( is_admin() && ( ! wp_doing_ajax() || $this->is_admin_referer() ) ) || empty( $hidden_posts ) ) {
 				return $where;
 			}
 
@@ -235,6 +235,17 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			$hidden_posts = get_option( 'unlist_posts', array() );
 
 			return implode( ', ', $hidden_posts );
+		}
+
+		/**
+		 * Check if the current AJAX request originated from an admin page.
+		 *
+		 * @since  1.2.0
+		 * @return boolean True if the AJAX request referer is an admin page.
+		 */
+		private function is_admin_referer() {
+			$referer = wp_get_referer();
+			return $referer && false !== strpos( $referer, admin_url() );
 		}
 
 		/**

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -244,6 +244,9 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 		 * @return boolean True if the AJAX request referer is an admin page.
 		 */
 		private function is_admin_referer() {
+			if ( ! current_user_can( 'edit_posts' ) ) {
+				return false;
+			}
 			$referer = wp_get_referer();
 			return $referer && false !== strpos( $referer, admin_url() );
 		}

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -248,8 +248,9 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			if ( ! current_user_can( 'edit_posts' ) ) {
 				return false;
 			}
+			// Require a starts-with match so an admin URL embedded as a query param on a frontend page can't pass the check.
 			$referer = wp_get_referer();
-			return $referer && false !== strpos( $referer, admin_url() );
+			return $referer && 0 === strpos( $referer, admin_url() );
 		}
 
 		/**

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -244,7 +244,8 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 		 * @return boolean True if the AJAX request referer is an admin page.
 		 */
 		private function is_admin_referer() {
-			if ( ! is_user_logged_in() ) {
+			// Require an editing capability so a spoofed admin Referer from a subscriber-level user can't unmask unlisted posts.
+			if ( ! current_user_can( 'edit_posts' ) ) {
 				return false;
 			}
 			$referer = wp_get_referer();

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -244,7 +244,7 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 		 * @return boolean True if the AJAX request referer is an admin page.
 		 */
 		private function is_admin_referer() {
-			if ( ! current_user_can( 'edit_posts' ) ) {
+			if ( ! is_user_logged_in() ) {
 				return false;
 			}
 			$referer = wp_get_referer();

--- a/class-unlist-posts.php
+++ b/class-unlist-posts.php
@@ -248,9 +248,35 @@ if ( ! class_exists( 'Unlist_Posts' ) ) {
 			if ( ! current_user_can( 'edit_posts' ) ) {
 				return false;
 			}
-			// Require a starts-with match so an admin URL embedded as a query param on a frontend page can't pass the check.
+
 			$referer = wp_get_referer();
-			return $referer && 0 === strpos( $referer, admin_url() );
+			if ( ! $referer ) {
+				return false;
+			}
+
+			$referer_parts = wp_parse_url( $referer );
+			$admin_parts   = wp_parse_url( admin_url() );
+			if ( ! is_array( $referer_parts ) || ! is_array( $admin_parts ) ) {
+				return false;
+			}
+
+			// Require a same-host match — scheme is deliberately ignored so HTTPS browsers behind a TLS-terminating proxy still work even when admin_url() returns HTTP.
+			if ( empty( $referer_parts['host'] ) || empty( $admin_parts['host'] ) ) {
+				return false;
+			}
+			if ( strtolower( $referer_parts['host'] ) !== strtolower( $admin_parts['host'] ) ) {
+				return false;
+			}
+
+			if ( empty( $referer_parts['path'] ) || empty( $admin_parts['path'] ) ) {
+				return false;
+			}
+
+			// trailingslashit on both sides so /wp-admin-foo/ can't false-match /wp-admin/.
+			$admin_path   = trailingslashit( $admin_parts['path'] );
+			$referer_path = trailingslashit( $referer_parts['path'] );
+
+			return 0 === strpos( $referer_path, $admin_path );
 		}
 
 		/**

--- a/tests/test-admin-ajax-visibility.php
+++ b/tests/test-admin-ajax-visibility.php
@@ -32,6 +32,18 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Restore global state mutated by individual tests so a failed assertion can't leak into later tests.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		unset( $_SERVER['HTTP_REFERER'] );
+		set_current_screen( 'front' );
+		parent::tearDown();
+	}
+
+	/**
 	 * Helper to unlist a post.
 	 *
 	 * @param int $post_id Post ID to unlist.
@@ -65,10 +77,6 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 		// Unlisted post should be visible in admin-originated AJAX.
 		$this->assertNotEmpty( $query->posts );
 		$this->assertEquals( $unlisted_post, $query->posts[0]->ID );
-
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-		unset( $_SERVER['HTTP_REFERER'] );
-		set_current_screen( 'front' );
 	}
 
 	/**
@@ -90,9 +98,6 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 
 		// Unlisted post should still be hidden in frontend AJAX.
 		$this->assertEmpty( $query->posts );
-
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-		unset( $_SERVER['HTTP_REFERER'] );
 	}
 
 	/**
@@ -118,10 +123,6 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 
 		// Unlisted post should still be hidden because user is not logged in.
 		$this->assertEmpty( $query->posts );
-
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-		unset( $_SERVER['HTTP_REFERER'] );
-		set_current_screen( 'front' );
 	}
 
 	/**
@@ -147,9 +148,5 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 
 		// Unlisted post should still be hidden — subscriber lacks edit_posts capability.
 		$this->assertEmpty( $query->posts );
-
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-		unset( $_SERVER['HTTP_REFERER'] );
-		set_current_screen( 'front' );
 	}
 }

--- a/tests/test-admin-ajax-visibility.php
+++ b/tests/test-admin-ajax-visibility.php
@@ -92,4 +92,31 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 		unset( $_SERVER['HTTP_REFERER'] );
 	}
+
+	/**
+	 * Test that unauthenticated users cannot bypass filtering by spoofing the admin referer.
+	 */
+	public function test_unlisted_post_hidden_for_unauthenticated_admin_ajax() {
+		$unlisted_post = self::factory()->post->create();
+		$this->unlist_post( $unlisted_post );
+
+		// Switch to a user with no capabilities.
+		wp_set_current_user( 0 );
+
+		// Simulate an AJAX request with a spoofed admin referer.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_SERVER['HTTP_REFERER'] = admin_url( 'user-edit.php?user_id=1' );
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		// Unlisted post should still be hidden because user lacks edit_posts capability.
+		$this->assertEmpty( $query->posts );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		unset( $_SERVER['HTTP_REFERER'] );
+	}
 }

--- a/tests/test-admin-ajax-visibility.php
+++ b/tests/test-admin-ajax-visibility.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Class TestAdminAjaxVisibility
+ *
+ * @package Unlist_Posts
+ */
+
+/**
+ * Make sure unlisted posts are visible in admin AJAX requests.
+ */
+class TestAdminAjaxVisibility extends WP_UnitTestCase {
+
+	/**
+	 * User ID for an editor user.
+	 *
+	 * @var int
+	 */
+	private $editor_user_id;
+
+	/**
+	 * Setup the tests class.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->editor_user_id = self::factory()->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+	}
+
+	/**
+	 * Helper to unlist a post.
+	 *
+	 * @param int $post_id Post ID to unlist.
+	 */
+	private function unlist_post( $post_id ) {
+		wp_set_current_user( $this->editor_user_id );
+		$_POST['unlist_posts']       = true;
+		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+	}
+
+	/**
+	 * Test that unlisted posts are visible in admin AJAX requests
+	 * originating from the admin panel (e.g., LearnDash group assignment).
+	 */
+	public function test_unlisted_post_visible_in_admin_ajax() {
+		$unlisted_post = self::factory()->post->create();
+		$this->unlist_post( $unlisted_post );
+
+		// Simulate an AJAX request originating from the admin panel.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_SERVER['HTTP_REFERER'] = admin_url( 'user-edit.php?user_id=1' );
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		// Unlisted post should be visible in admin-originated AJAX.
+		$this->assertNotEmpty( $query->posts );
+		$this->assertEquals( $unlisted_post, $query->posts[0]->ID );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		unset( $_SERVER['HTTP_REFERER'] );
+	}
+
+	/**
+	 * Test that unlisted posts are still hidden in frontend AJAX requests.
+	 */
+	public function test_unlisted_post_hidden_in_frontend_ajax() {
+		$unlisted_post = self::factory()->post->create();
+		$this->unlist_post( $unlisted_post );
+
+		// Simulate an AJAX request originating from the frontend.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_SERVER['HTTP_REFERER'] = home_url( '/members-area/' );
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		// Unlisted post should still be hidden in frontend AJAX.
+		$this->assertEmpty( $query->posts );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		unset( $_SERVER['HTTP_REFERER'] );
+	}
+}

--- a/tests/test-admin-ajax-visibility.php
+++ b/tests/test-admin-ajax-visibility.php
@@ -51,7 +51,8 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 		$unlisted_post = self::factory()->post->create();
 		$this->unlist_post( $unlisted_post );
 
-		// Simulate an AJAX request originating from the admin panel.
+		// Simulate an admin AJAX request originating from the admin panel.
+		set_current_screen( 'dashboard' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
 		$_SERVER['HTTP_REFERER'] = admin_url( 'user-edit.php?user_id=1' );
 
@@ -67,6 +68,7 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 		unset( $_SERVER['HTTP_REFERER'] );
+		set_current_screen( 'front' );
 	}
 
 	/**
@@ -104,6 +106,7 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		// Simulate an AJAX request with a spoofed admin referer.
+		set_current_screen( 'dashboard' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
 		$_SERVER['HTTP_REFERER'] = admin_url( 'user-edit.php?user_id=1' );
 
@@ -118,5 +121,6 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 		unset( $_SERVER['HTTP_REFERER'] );
+		set_current_screen( 'front' );
 	}
 }

--- a/tests/test-admin-ajax-visibility.php
+++ b/tests/test-admin-ajax-visibility.php
@@ -39,6 +39,9 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 	public function tearDown(): void {
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 		unset( $_SERVER['HTTP_REFERER'] );
+		// Clear save_meta inputs and the persisted hidden-posts option so a leaked $_POST or option can't silently unlist posts created by later tests.
+		unset( $_POST['unlist_posts'], $_POST['unlist_post_nounce'] );
+		delete_option( 'unlist_posts' );
 		set_current_screen( 'front' );
 		parent::tearDown();
 	}
@@ -74,9 +77,8 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 			)
 		);
 
-		// Unlisted post should be visible in admin-originated AJAX.
-		$this->assertNotEmpty( $query->posts );
-		$this->assertEquals( $unlisted_post, $query->posts[0]->ID );
+		// Unlisted post should be visible in admin-originated AJAX. Use assertContains so the test isn't sensitive to result ordering or other posts in the DB.
+		$this->assertContains( $unlisted_post, wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
 	/**
@@ -86,7 +88,8 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 		$unlisted_post = self::factory()->post->create();
 		$this->unlist_post( $unlisted_post );
 
-		// Simulate an AJAX request originating from the frontend.
+		// Simulate an admin-ajax.php request initiated from the frontend (admin-ajax.php sets is_admin() to true, so set the screen to match).
+		set_current_screen( 'dashboard' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
 		$_SERVER['HTTP_REFERER'] = home_url( '/members-area/' );
 

--- a/tests/test-admin-ajax-visibility.php
+++ b/tests/test-admin-ajax-visibility.php
@@ -102,7 +102,7 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 		$unlisted_post = self::factory()->post->create();
 		$this->unlist_post( $unlisted_post );
 
-		// Switch to a user with no capabilities.
+		// Switch to a logged-out user.
 		wp_set_current_user( 0 );
 
 		// Simulate an AJAX request with a spoofed admin referer.
@@ -116,7 +116,7 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 			)
 		);
 
-		// Unlisted post should still be hidden because user lacks edit_posts capability.
+		// Unlisted post should still be hidden because user is not logged in.
 		$this->assertEmpty( $query->posts );
 
 		remove_filter( 'wp_doing_ajax', '__return_true' );

--- a/tests/test-admin-ajax-visibility.php
+++ b/tests/test-admin-ajax-visibility.php
@@ -123,4 +123,33 @@ class TestAdminAjaxVisibility extends WP_UnitTestCase {
 		unset( $_SERVER['HTTP_REFERER'] );
 		set_current_screen( 'front' );
 	}
+
+	/**
+	 * Test that subscriber-level users cannot bypass filtering by spoofing the admin referer.
+	 */
+	public function test_unlisted_post_hidden_for_subscriber_with_spoofed_referer() {
+		$unlisted_post = self::factory()->post->create();
+		$this->unlist_post( $unlisted_post );
+
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		// Simulate an AJAX request with a spoofed admin referer from a low-privilege user.
+		set_current_screen( 'dashboard' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_SERVER['HTTP_REFERER'] = admin_url( 'user-edit.php?user_id=1' );
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		// Unlisted post should still be hidden — subscriber lacks edit_posts capability.
+		$this->assertEmpty( $query->posts );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		unset( $_SERVER['HTTP_REFERER'] );
+		set_current_screen( 'front' );
+	}
 }


### PR DESCRIPTION
### Description
This change ensures that unlisted posts remain visible in AJAX requests originating from the WordPress admin panel, while staying hidden in frontend AJAX requests. This is important for admin functionality like LearnDash group assignments that rely on AJAX to query posts.

The fix adds a new `is_admin_referer()` method that checks if an AJAX request's HTTP referer originates from an admin page. The visibility logic in `where_clause()` and `post_navigation_clause()` now uses this check to distinguish between admin-originated and frontend-originated AJAX requests.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Added comprehensive unit tests in `TestAdminAjaxVisibility` class:
- `test_unlisted_post_visible_in_admin_ajax()` - Verifies unlisted posts are visible in admin-originated AJAX requests
- `test_unlisted_post_hidden_in_frontend_ajax()` - Verifies unlisted posts remain hidden in frontend AJAX requests

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [x] I've included any necessary tests

https://claude.ai/code/session_01YC7zLpmtuskzxXG5wH8ewP