### PR TITLE
feat: Add Quick Edit and Bulk Edit support for unlisting posts

### DIFF
--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -43,6 +43,194 @@ class Unlist_Posts_Admin {
 		add_filter( 'display_post_states', array( $this, 'add_unlisted_post_status' ), 10, 2 );
 		add_filter( 'parse_query', array( $this, 'filter_unlisted_posts' ) );
 		add_action( 'init', array( $this, 'add_post_filter' ) );
+		add_action( 'admin_init', array( $this, 'register_list_table_hooks' ) );
+		add_action( 'quick_edit_custom_box', array( $this, 'quick_edit_field' ), 10, 2 );
+		add_action( 'bulk_edit_custom_box', array( $this, 'bulk_edit_field' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_inline_edit_script' ) );
+	}
+
+	/**
+	 * Return the list of public post types the plugin operates on.
+	 *
+	 * @return array
+	 */
+	private function get_supported_post_types() {
+		return get_post_types( array( 'public' => true ), 'names', 'and' );
+	}
+
+	/**
+	 * Register the Unlisted column on every supported post-type list table.
+	 *
+	 * The custom column is required for `quick_edit_custom_box` and
+	 * `bulk_edit_custom_box` to fire for our field.
+	 */
+	public function register_list_table_hooks() {
+		foreach ( $this->get_supported_post_types() as $post_type ) {
+			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'add_status_column' ) );
+			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'render_status_column' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Add the Unlisted column header.
+	 *
+	 * @param array $columns Existing list table columns.
+	 * @return array
+	 */
+	public function add_status_column( $columns ) {
+		$columns['unlist_posts_status'] = __( 'Unlisted', 'unlist-posts' );
+		return $columns;
+	}
+
+	/**
+	 * Render the Unlisted column cell. The data-unlisted attribute is read by JS
+	 * to pre-check the Quick Edit checkbox.
+	 *
+	 * @param string $column  Column key being rendered.
+	 * @param int    $post_id Post being rendered.
+	 */
+	public function render_status_column( $column, $post_id ) {
+		if ( 'unlist_posts_status' !== $column ) {
+			return;
+		}
+
+		$unlisted = $this->is_unlisted( $post_id );
+		printf(
+			'<span class="unlist-posts-status" data-unlisted="%s">%s</span>',
+			esc_attr( $unlisted ? '1' : '0' ),
+			$unlisted ? esc_html__( 'Yes', 'unlist-posts' ) : '&mdash;'
+		);
+	}
+
+	/**
+	 * Output the Quick Edit checkbox.
+	 *
+	 * @param string $column    Column key.
+	 * @param string $post_type Post type being edited.
+	 */
+	public function quick_edit_field( $column, $post_type ) {
+		if ( 'unlist_posts_status' !== $column ) {
+			return;
+		}
+		if ( ! in_array( $post_type, $this->get_supported_post_types(), true ) ) {
+			return;
+		}
+		wp_nonce_field( 'unlist_posts_quick_edit', 'unlist_posts_qe_nonce' );
+		?>
+		<fieldset class="inline-edit-col-right">
+			<div class="inline-edit-col">
+				<label class="alignleft">
+					<input type="checkbox" name="unlist_posts_quick_edit" value="1" />
+					<span class="checkbox-title"><?php esc_html_e( 'Unlist this post', 'unlist-posts' ); ?></span>
+				</label>
+			</div>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Output the Bulk Edit tri-state select.
+	 *
+	 * @param string $column    Column key.
+	 * @param string $post_type Post type being edited.
+	 */
+	public function bulk_edit_field( $column, $post_type ) {
+		if ( 'unlist_posts_status' !== $column ) {
+			return;
+		}
+		if ( ! in_array( $post_type, $this->get_supported_post_types(), true ) ) {
+			return;
+		}
+		?>
+		<fieldset class="inline-edit-col-right">
+			<div class="inline-edit-col">
+				<label class="inline-edit-group">
+					<span class="title"><?php esc_html_e( 'Unlisted', 'unlist-posts' ); ?></span>
+					<select name="unlist_posts_bulk_edit">
+						<option value="-1"><?php esc_html_e( '&mdash; No Change &mdash;', 'unlist-posts' ); ?></option>
+						<option value="unlist"><?php esc_html_e( 'Unlist', 'unlist-posts' ); ?></option>
+						<option value="list"><?php esc_html_e( 'List', 'unlist-posts' ); ?></option>
+					</select>
+				</label>
+			</div>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Enqueue inline JS that pre-checks the Quick Edit checkbox based on the
+	 * row's current state.
+	 *
+	 * @param string $hook Current admin page hook.
+	 */
+	public function enqueue_inline_edit_script( $hook ) {
+		if ( 'edit.php' !== $hook ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+		if ( ! $screen || ! in_array( $screen->post_type, $this->get_supported_post_types(), true ) ) {
+			return;
+		}
+
+		$script = <<<'JS'
+(function($) {
+	if ( typeof inlineEditPost === 'undefined' ) {
+		return;
+	}
+	var origEdit = inlineEditPost.edit;
+	inlineEditPost.edit = function( id ) {
+		origEdit.apply( this, arguments );
+		var postId = 0;
+		if ( typeof id === 'object' ) {
+			postId = parseInt( this.getId( id ), 10 );
+		} else {
+			postId = parseInt( id, 10 );
+		}
+		if ( ! postId ) {
+			return;
+		}
+		var unlisted = $( '#post-' + postId ).find( '.unlist-posts-status' ).data( 'unlisted' );
+		$( '.inline-edit-row' )
+			.find( 'input[name="unlist_posts_quick_edit"]' )
+			.prop( 'checked', String( unlisted ) === '1' );
+	};
+})(jQuery);
+JS;
+		wp_add_inline_script( 'inline-edit-post', $script );
+	}
+
+	/**
+	 * Whether a post is currently in the unlisted option list.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	private function is_unlisted( $post_id ) {
+		$hidden_posts = (array) get_option( 'unlist_posts', array() );
+		return in_array( (int) $post_id, array_map( 'intval', $hidden_posts ), true );
+	}
+
+	/**
+	 * Add or remove a post ID in the unlisted option.
+	 *
+	 * @param int  $post_id Post ID.
+	 * @param bool $unlist  True to unlist, false to list.
+	 */
+	private function set_unlisted( $post_id, $unlist ) {
+		$post_id      = (int) $post_id;
+		$hidden_posts = (array) get_option( 'unlist_posts', array() );
+
+		if ( $unlist ) {
+			if ( ! in_array( $post_id, $hidden_posts, true ) ) {
+				$hidden_posts[] = $post_id;
+			}
+			$hidden_posts = array_unique( $hidden_posts );
+		} else {
+			$hidden_posts = array_values( array_diff( $hidden_posts, array( $post_id ) ) );
+		}
+
+		update_option( 'unlist_posts', $hidden_posts );
 	}
 
 	/**
@@ -100,54 +288,51 @@ class Unlist_Posts_Admin {
 	}
 
 	/**
-	 * Save meta field.
+	 * Save meta field. Dispatches to the appropriate flow:
+	 * Bulk Edit, Quick Edit, or the post-edit metabox.
 	 *
-	 * @param  POST $post_id Currennt post object which is being displayed.
+	 * @param  int $post_id Current post being saved.
 	 *
-	 * @return Void
+	 * @return void
 	 */
 	public function save_meta( $post_id ) {
-		// Bail if we're doing an auto save.
+		// Bail if we're doing an auto save or on a revision.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
-
-		// if our nonce isn't there, or we can't verify it, bail.
-		if ( ! isset( $_POST['unlist_post_nounce'] ) || ! wp_verify_nonce( $_POST['unlist_post_nounce'], 'unlist_post_nounce' ) ) {
-			return;
-		}
-
-		// if our current user can't edit this post, bail.
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return;
-		}
-
-		// Don't record unlist option for revisions.
 		if ( false !== wp_is_post_revision( $post_id ) ) {
 			return;
 		}
-
-		$hidden_posts = get_option( 'unlist_posts', array() );
-
-		if ( '' === $hidden_posts ) {
-			$hidden_posts = array();
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
 		}
 
-		if ( isset( $_POST['unlist_posts'] ) ) {
-			$hidden_posts[] = $post_id;
-
-			// Get only the unique post id's in the option array.
-			$hidden_posts = array_unique( $hidden_posts );
-		} elseif ( in_array( $post_id, $hidden_posts, true ) ) {
-
-			// Get only the unique post id's in the option array.
-			$hidden_posts = array_unique( $hidden_posts );
-
-			$key = array_search( $post_id, $hidden_posts, true );
-			unset( $hidden_posts[ $key ] );
+		// Bulk Edit: nonce is verified by core in edit.php (bulk-posts) before
+		// bulk_edit_posts() loops and triggers save_post per ID.
+		if ( isset( $_REQUEST['bulk_edit'] ) && isset( $_REQUEST['unlist_posts_bulk_edit'] ) ) {
+			$value = sanitize_text_field( wp_unslash( $_REQUEST['unlist_posts_bulk_edit'] ) );
+			if ( 'unlist' === $value ) {
+				$this->set_unlisted( $post_id, true );
+			} elseif ( 'list' === $value ) {
+				$this->set_unlisted( $post_id, false );
+			}
+			return;
 		}
 
-		update_option( 'unlist_posts', $hidden_posts );
+		// Quick Edit.
+		if ( isset( $_POST['unlist_posts_qe_nonce'] ) ) {
+			if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['unlist_posts_qe_nonce'] ) ), 'unlist_posts_quick_edit' ) ) {
+				return;
+			}
+			$this->set_unlisted( $post_id, isset( $_POST['unlist_posts_quick_edit'] ) );
+			return;
+		}
+
+		// Post-edit metabox.
+		if ( ! isset( $_POST['unlist_post_nounce'] ) || ! wp_verify_nonce( $_POST['unlist_post_nounce'], 'unlist_post_nounce' ) ) {
+			return;
+		}
+		$this->set_unlisted( $post_id, isset( $_POST['unlist_posts'] ) );
 	}
 
 	/**

--- a/class-unlist-posts-admin.php
+++ b/class-unlist-posts-admin.php
@@ -147,7 +147,7 @@ class Unlist_Posts_Admin {
 				<label class="inline-edit-group">
 					<span class="title"><?php esc_html_e( 'Unlisted', 'unlist-posts' ); ?></span>
 					<select name="unlist_posts_bulk_edit">
-						<option value="-1"><?php esc_html_e( '&mdash; No Change &mdash;', 'unlist-posts' ); ?></option>
+						<option value="-1"><?php esc_html_e( '— No Change —', 'unlist-posts' ); ?></option>
 						<option value="unlist"><?php esc_html_e( 'Unlist', 'unlist-posts' ); ?></option>
 						<option value="list"><?php esc_html_e( 'List', 'unlist-posts' ); ?></option>
 					</select>
@@ -201,14 +201,39 @@ JS;
 	}
 
 	/**
+	 * Get the unlisted post IDs as a clean array of integers.
+	 *
+	 * Legacy installs may have stored the option as an empty string, so we
+	 * normalize aggressively before any read or write.
+	 *
+	 * @return int[]
+	 */
+	private function get_unlisted_ids() {
+		$stored = get_option( 'unlist_posts', array() );
+
+		if ( ! is_array( $stored ) ) {
+			return array();
+		}
+
+		$ids = array_map( 'intval', $stored );
+		$ids = array_filter(
+			$ids,
+			function( $id ) {
+				return $id > 0;
+			}
+		);
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
 	 * Whether a post is currently in the unlisted option list.
 	 *
 	 * @param int $post_id Post ID.
 	 * @return bool
 	 */
 	private function is_unlisted( $post_id ) {
-		$hidden_posts = (array) get_option( 'unlist_posts', array() );
-		return in_array( (int) $post_id, array_map( 'intval', $hidden_posts ), true );
+		return in_array( (int) $post_id, $this->get_unlisted_ids(), true );
 	}
 
 	/**
@@ -219,13 +244,12 @@ JS;
 	 */
 	private function set_unlisted( $post_id, $unlist ) {
 		$post_id      = (int) $post_id;
-		$hidden_posts = (array) get_option( 'unlist_posts', array() );
+		$hidden_posts = $this->get_unlisted_ids();
 
 		if ( $unlist ) {
 			if ( ! in_array( $post_id, $hidden_posts, true ) ) {
 				$hidden_posts[] = $post_id;
 			}
-			$hidden_posts = array_unique( $hidden_posts );
 		} else {
 			$hidden_posts = array_values( array_diff( $hidden_posts, array( $post_id ) ) );
 		}
@@ -307,9 +331,15 @@ JS;
 			return;
 		}
 
-		// Bulk Edit: nonce is verified by core in edit.php (bulk-posts) before
-		// bulk_edit_posts() loops and triggers save_post per ID.
+		// Bulk Edit. Core verifies the bulk-posts nonce in edit.php before
+		// bulk_edit_posts() runs, but we re-verify here for defense in depth so
+		// stray $_REQUEST keys in unrelated save_post contexts cannot trigger
+		// an update.
 		if ( isset( $_REQUEST['bulk_edit'] ) && isset( $_REQUEST['unlist_posts_bulk_edit'] ) ) {
+			if ( empty( $_REQUEST['_wpnonce'] ) ||
+				! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'bulk-posts' ) ) {
+				return;
+			}
 			$value = sanitize_text_field( wp_unslash( $_REQUEST['unlist_posts_bulk_edit'] ) );
 			if ( 'unlist' === $value ) {
 				$this->set_unlisted( $post_id, true );

--- a/tests/test-save-meta.php
+++ b/tests/test-save-meta.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Class TestSaveMeta
+ *
+ * @package Unlist_Posts
+ */
+
+/**
+ * Cover the three save_meta() dispatch flows: metabox, Quick Edit, Bulk Edit.
+ */
+class TestSaveMeta extends WP_UnitTestCase {
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	private $editor_user_id;
+
+	/**
+	 * Set up a privileged user and reset shared state.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->editor_user_id = self::factory()->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+		wp_set_current_user( $this->editor_user_id );
+
+		delete_option( 'unlist_posts' );
+		$_POST    = array();
+		$_REQUEST = array();
+	}
+
+	/**
+	 * Tear down request globals to avoid leaking state between tests.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$_POST    = array();
+		$_REQUEST = array();
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper: return the currently unlisted post IDs.
+	 *
+	 * @return array
+	 */
+	private function unlisted_ids() {
+		$stored = get_option( 'unlist_posts', array() );
+		if ( ! is_array( $stored ) ) {
+			return array();
+		}
+		return array_values( array_map( 'intval', $stored ) );
+	}
+
+	/* ------------------------------------------------------------------
+	 * Metabox flow.
+	 * ------------------------------------------------------------------ */
+
+	/**
+	 * Metabox checked: post is added to the option.
+	 */
+	public function test_metabox_checked_unlists_post() {
+		$post_id = self::factory()->post->create();
+
+		$_POST['unlist_posts']       = '1';
+		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/**
+	 * Metabox unchecked on a previously unlisted post: post is removed.
+	 */
+	public function test_metabox_unchecked_lists_post() {
+		$post_id = self::factory()->post->create();
+		update_option( 'unlist_posts', array( $post_id ) );
+
+		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertNotContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/**
+	 * Metabox flow with an invalid nonce: option is left untouched.
+	 */
+	public function test_metabox_bad_nonce_is_ignored() {
+		$post_id = self::factory()->post->create();
+
+		$_POST['unlist_posts']       = '1';
+		$_POST['unlist_post_nounce'] = 'not-a-real-nonce';
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertNotContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/* ------------------------------------------------------------------
+	 * Quick Edit flow.
+	 * ------------------------------------------------------------------ */
+
+	/**
+	 * Quick Edit checkbox checked: post is added.
+	 */
+	public function test_quick_edit_checked_unlists_post() {
+		$post_id = self::factory()->post->create();
+
+		$_POST['unlist_posts_quick_edit'] = '1';
+		$_POST['unlist_posts_qe_nonce']   = wp_create_nonce( 'unlist_posts_quick_edit' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/**
+	 * Quick Edit checkbox unchecked: post is removed.
+	 */
+	public function test_quick_edit_unchecked_lists_post() {
+		$post_id = self::factory()->post->create();
+		update_option( 'unlist_posts', array( $post_id ) );
+
+		// Checkbox absent in $_POST signals "unchecked".
+		$_POST['unlist_posts_qe_nonce'] = wp_create_nonce( 'unlist_posts_quick_edit' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertNotContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/**
+	 * Quick Edit with an invalid nonce: option is left untouched.
+	 */
+	public function test_quick_edit_bad_nonce_is_ignored() {
+		$post_id = self::factory()->post->create();
+
+		$_POST['unlist_posts_quick_edit'] = '1';
+		$_POST['unlist_posts_qe_nonce']   = 'not-a-real-nonce';
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertNotContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/* ------------------------------------------------------------------
+	 * Bulk Edit flow.
+	 * ------------------------------------------------------------------ */
+
+	/**
+	 * Bulk Edit "unlist": post is added.
+	 */
+	public function test_bulk_edit_unlist_adds_post() {
+		$post_id = self::factory()->post->create();
+
+		$_REQUEST['bulk_edit']              = 'Update';
+		$_REQUEST['unlist_posts_bulk_edit'] = 'unlist';
+		$_REQUEST['_wpnonce']               = wp_create_nonce( 'bulk-posts' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/**
+	 * Bulk Edit "list": post is removed.
+	 */
+	public function test_bulk_edit_list_removes_post() {
+		$post_id = self::factory()->post->create();
+		update_option( 'unlist_posts', array( $post_id ) );
+
+		$_REQUEST['bulk_edit']              = 'Update';
+		$_REQUEST['unlist_posts_bulk_edit'] = 'list';
+		$_REQUEST['_wpnonce']               = wp_create_nonce( 'bulk-posts' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertNotContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/**
+	 * Bulk Edit value "-1" ("No Change"): state is preserved.
+	 */
+	public function test_bulk_edit_no_change_preserves_state() {
+		$unlisted = self::factory()->post->create();
+		$listed   = self::factory()->post->create();
+		update_option( 'unlist_posts', array( $unlisted ) );
+
+		$_REQUEST['bulk_edit']              = 'Update';
+		$_REQUEST['unlist_posts_bulk_edit'] = '-1';
+		$_REQUEST['_wpnonce']               = wp_create_nonce( 'bulk-posts' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $unlisted );
+		Unlist_Posts_Admin::instance()->save_meta( $listed );
+
+		$ids = $this->unlisted_ids();
+		$this->assertContains( $unlisted, $ids );
+		$this->assertNotContains( $listed, $ids );
+	}
+
+	/**
+	 * Bulk Edit with an invalid nonce: option is left untouched.
+	 */
+	public function test_bulk_edit_bad_nonce_is_ignored() {
+		$post_id = self::factory()->post->create();
+
+		$_REQUEST['bulk_edit']              = 'Update';
+		$_REQUEST['unlist_posts_bulk_edit'] = 'unlist';
+		$_REQUEST['_wpnonce']               = 'not-a-real-nonce';
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$this->assertNotContains( $post_id, $this->unlisted_ids() );
+	}
+
+	/* ------------------------------------------------------------------
+	 * Option normalization.
+	 * ------------------------------------------------------------------ */
+
+	/**
+	 * If a legacy install stored '' as the option, the save flow must not
+	 * persist an empty-string entry back into the array.
+	 */
+	public function test_save_normalizes_legacy_empty_string_option() {
+		update_option( 'unlist_posts', '' );
+
+		$post_id = self::factory()->post->create();
+
+		$_POST['unlist_posts']       = '1';
+		$_POST['unlist_post_nounce'] = wp_create_nonce( 'unlist_post_nounce' );
+
+		Unlist_Posts_Admin::instance()->save_meta( $post_id );
+
+		$stored = get_option( 'unlist_posts' );
+		$this->assertSame( array( $post_id ), array_values( $stored ) );
+	}
+}


### PR DESCRIPTION
### Description

Adds Quick Edit and Bulk Edit support for the Unlist Posts plugin so authors can toggle the unlisted state directly from the post list table without opening each post.

Closes #127
Closes #16

**What's new:**
- New **Unlisted** column on every public post-type list table (shows `Yes` / `—`).
- **Quick Edit**: a checkbox to unlist the current post. The checkbox is pre-checked via inline JS based on the row's current state (read from a `data-unlisted` attribute on the column cell).
- **Bulk Edit**: a tri-state select (`— No Change —` / `Unlist` / `List`) so you can flip many posts at once.
- Refactored `save_meta` to dispatch between three flows — Bulk Edit, Quick Edit, and the existing post-edit metabox — via a shared `set_unlisted( $post_id, $unlist )` helper. Centralizing the option mutation removes the duplicated `array_unique` / `array_search` logic from the old metabox-only path.
- Added a private `is_unlisted()` helper and `get_supported_post_types()` so the column and edit fields are registered consistently.
- Nonce verification for Quick Edit (`unlist_posts_qe_nonce` / `unlist_posts_quick_edit`); Bulk Edit relies on core's `bulk-posts` nonce that `edit.php` verifies before dispatching `save_post`.
- Capability check tightened from `edit_posts` to `edit_post` for the specific post being saved.

### Types of changes

- New feature (non-breaking change which adds functionality)

### How has this been tested?

Manually on a local WordPress install:

- [x] Quick Edit on a listed post → check the box → Update → row shows `Yes`, post hidden from public queries.
- [x] Quick Edit on an unlisted post → checkbox pre-checked → uncheck → Update → row shows `—`, post visible again.
- [x] Bulk Edit with `— No Change —` does not modify any row.
- [x] Bulk Edit with `Unlist` flips all selected posts to unlisted.
- [x] Bulk Edit with `List` flips all selected posts back.
- [x] Existing post-edit metabox still works (save/unsave from the edit screen).
- [x] Verified on `post` and `page` post types, and a custom public CPT.

### Checklist:
- [ ] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [ ] I've included any necessary tests
- [ ] I've included developer documentation
- [x] I've added proper labels to this pull request