### PR TITLE
Pin Composer platform PHP to 7.4 for reproducible installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "yoast/phpunit-polyfills": "^1.0"
   },
   "config": {
+    "platform": {
+      "php": "7.4"
+    },
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "roots/wordpress-core-installer": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8fe5405901a6600b3b8adb3a261779af",
+    "content-hash": "792026e1a469fba41a63c8d3646f0dc4",
     "packages": [],
     "packages-dev": [
         {
@@ -2371,5 +2371,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
### Description

Adds `config.platform.php: "7.4"` to `composer.json` and regenerates `composer.lock` so Composer resolves dependencies against the lowest PHP version we support, not the host's PHP.

**Why:** Dependabot recently rebased [#135](https://github.com/Nikschavan/unlist-posts/pull/135) and the regenerated lock pulled in `doctrine/instantiator 2.1.0`, which requires PHP `^8.4`. That broke `composer install --locked` on the PHP 7.4 CI matrix:

```
doctrine/instantiator 2.1.0 requires php ^8.4 -> your php version (7.4.33) does not satisfy that requirement.
phpunit/phpunit 9.6.34 requires doctrine/instantiator ^1.5.0 || ^2 -> satisfiable by doctrine/instantiator[2.1.0].
##[error]Your lock file does not contain a compatible set of packages.
```

With the platform constraint in place, the lock resolves `doctrine/instantiator` back to `1.5.0`, and future Dependabot rebases won't pick up packages that drop PHP 7.4 support.

### Types of changes

- Bug fix (CI / build tooling)

### How has this been tested?

Ran `composer update --lock` locally — install succeeds and `doctrine/instantiator` resolves to `1.5.0`. Once this lands on master, Dependabot can rebase [#135](https://github.com/Nikschavan/unlist-posts/pull/135) and CI should go green there too.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards
- [ ] My code has proper inline documentation
- [ ] I've included any necessary tests
- [ ] I've included developer documentation
- [ ] I've added proper labels to this pull request