### PR TITLE
chore: release 1.2.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Just select option "Unlist Post" in any post of any type and that post will be h
 == Changelog ==
 
 = 1.2.1 =
-- Fix: Fatal `TypeError` on PHP 8.x when viewing the post list with `?post_status=unlisted` and another plugin in the `display_post_states` filter chain declares a strict `array` type hint (e.g. SureDash). The early-return path now returns the `$states` array instead of `null`.
+- Fix: Fatal `TypeError` on PHP 8.x when viewing the post list with `?post_status=unlisted` and another plugin in the `display_post_states` filter chain declares a strict `array` type hint. The early-return path now returns the `$states` array instead of `null`.
 
 = 1.2.0 =
 - New: Quick Edit and Bulk Edit support to unlist or list posts directly from the post list table, plus a new "Unlisted" column on public post types.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Nikschavan
 Tags: post, unlist posts, hide posts,
 Requires at least: 4.6
 Tested up to: 7.0
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,9 @@ Need help with something? Have an issue to report? [Get in touch](https://github
 Just select option "Unlist Post" in any post of any type and that post will be hidden from the whole site, it can be only accessed if you have the direct link to the post.
 
 == Changelog ==
+
+= 1.2.1 =
+- Fix: Fatal `TypeError` on PHP 8.x when viewing the post list with `?post_status=unlisted` and another plugin in the `display_post_states` filter chain declares a strict `array` type hint (e.g. SureDash). The early-return path now returns the `$states` array instead of `null`.
 
 = 1.2.0 =
 - New: Quick Edit and Bulk Edit support to unlist or list posts directly from the post list table, plus a new "Unlisted" column on public post types.

--- a/unlist-posts.php
+++ b/unlist-posts.php
@@ -6,7 +6,7 @@
  * Author:          Nikhil Chavan
  * Author URI:      https://www.nikhilchavan.com/
  * Text Domain:     unlist-posts
- * Version:         1.2.0
+ * Version:         1.2.1
  *
  * @package         Hide_Post
  */
@@ -15,6 +15,6 @@ defined( 'ABSPATH' ) or exit;
 
 define( 'UNLIST_POSTS_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UNLIST_POSTS_URI', plugins_url( '/', __FILE__ ) );
-define( 'UNLIST_POSTS_VER', '1.2.0' );
+define( 'UNLIST_POSTS_VER', '1.2.1' );
 
 require_once UNLIST_POSTS_DIR . 'class-unlist-posts.php';


### PR DESCRIPTION
### Description

Release 1.2.1 — bumps the plugin version and documents the PHP 8.x `TypeError` fix in `display_post_states` for the unlisted post status filter (merged in #145).

- Bump `Stable tag` in `readme.txt` to 1.2.1
- Bump `Version` header and `UNLIST_POSTS_VER` constant in `unlist-posts.php` to 1.2.1
- Add 1.2.1 changelog entry covering the early-return fix in `add_unlisted_post_status()` that returned `null` and broke strict-typed downstream filters (e.g. SureDash) on PHP 8.x

### Screenshots

n/a

### Types of changes

Bug fix release (no behavior changes beyond what landed in #145).

### How has this been tested?

- Verified diff against master: only version strings and changelog entry change in this PR
- Underlying fix tested and merged via #145

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [x] My code follows accessibility standards
- [x] My code has proper inline documentation
- [ ] I've included any necessary tests
- [ ] I've included developer documentation
- [ ] I've added proper labels to this pull request